### PR TITLE
add operator for g++ compiler

### DIFF
--- a/include/oc_rep.h
+++ b/include/oc_rep.h
@@ -27,6 +27,14 @@
 extern CborEncoder g_encoder, root_map, links_array;
 extern CborError g_err;
 
+#ifdef __cplusplus
+inline CborError& operator |=(CborError& a, CborError b)
+{
+    return a = (CborError)((int)a |(int)b);
+}
+#endif
+
+
 void oc_rep_new(uint8_t *payload, int size);
 int oc_rep_finalize(void);
 


### PR DESCRIPTION
Some project (ex. Riot) can use c++ compiler but, this enum type can't operate in c++.