### PR TITLE
Fix segmentation fault in `oc_ri_process_discovery_payload`

### DIFF
--- a/api/oc_discovery.c
+++ b/api/oc_discovery.c
@@ -503,7 +503,7 @@ oc_ri_process_discovery_payload(uint8_t *payload, int len,
    *  object. It is traversed in the following loop to obtain a handle to its
    *  array of links.
    */
-  if (rep->value.object) {
+  if (rep != NULL && rep->value.object) {
     rep = rep->value.object;
   }
 

--- a/api/oc_rep.c
+++ b/api/oc_rep.c
@@ -384,6 +384,8 @@ oc_parse_rep(const uint8_t *in_payload, int payload_size, oc_rep_t **out_rep)
         return err;
       err |= cbor_value_advance(&map);
     }
+  } else {
+    *out_rep = 0;
   }
   return err;
 }


### PR DESCRIPTION
I believe I found a bug causing a segmentation fault in iotivity-constrained that has been introduced in commit a7a84258a9aad3886e140e46fa5c7a98a201d034 (see commit description for more information).

I initially reached out to @kmaloor who made the commit referenced above via mail on the 4th of April but never received a response. I also briefly read the contribution instruction on the iotivity website but I am neither willing nor interested to interact with gerrit. I am therefore opening a PR for fixing the segfault. I hope you don't mind that.

Take it or leave it.